### PR TITLE
Ensure that the app user owns the app directories

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ RUN \
 USER default
 WORKDIR /opt/app
 
-COPY --from=0 /opt/app/_build/prod/rel/wocky_db_watcher ./
+COPY --from=0 --chown=default:root /opt/app/_build/prod/rel/wocky_db_watcher ./
 
 ENTRYPOINT ["bin/wocky_db_watcher"]
 CMD ["foreground"]


### PR DESCRIPTION
This fixes an issue with tzdata failing to update itself and crashing.